### PR TITLE
[codex] Back off GitHub token refresh retries

### DIFF
--- a/src/ClaudeBox.jl
+++ b/src/ClaudeBox.jl
@@ -31,6 +31,8 @@ const VERSION = "1.0.0"
 const SANDBOX_GITHUB_AUTH_DIR = "/run/claudebox-github"
 const SANDBOX_GITHUB_TOKEN_FILE = "$SANDBOX_GITHUB_AUTH_DIR/token"
 const GITHUB_TOKEN_REFRESH_SKEW_SECONDS = 5 * 60
+const GITHUB_TOKEN_REFRESH_INITIAL_RETRY_SECONDS = 5 * 60.0
+const GITHUB_TOKEN_REFRESH_MAX_RETRY_SECONDS = 60 * 60.0
 
 # Helper functions for colored output
 cprintln(color, text) = println(color, text, RESET)
@@ -154,13 +156,14 @@ function _main(args::Vector{String})::Cint
         # expiry time.
         if has_github_refresh_token(state)
             cprintln(YELLOW, "Refreshing GitHub token...")
-            if refresh_github_token!(state; verbose=true)
+            refresh_result = refresh_github_token_result!(state; verbose=true)
+            if refresh_result.success
                 cprintln(GREEN, "✓ GitHub token refreshed successfully")
             elseif !isempty(state.github_token) && GitHubAuth.validate_token(state.github_token; silent=true)
-                cprintln(YELLOW, "⚠ Failed to refresh GitHub token; using existing valid token")
+                cprintln(YELLOW, "⚠ Failed to refresh GitHub token ($(refresh_result.reason)); using existing valid token")
                 write_sandbox_github_token(state)
             else
-                cprintln(YELLOW, "Failed to refresh token, requesting new authentication...")
+                cprintln(YELLOW, "Failed to refresh token ($(refresh_result.reason)), requesting new authentication...")
                 state.github_token = ""
                 state.github_refresh_token = nothing
                 state.github_token_expires_at = nothing
@@ -637,22 +640,26 @@ function write_sandbox_github_token(state::AppState)
     return nothing
 end
 
-function refresh_github_token!(state::AppState; verbose::Bool=false)
-    has_github_refresh_token(state) || return false
+function refresh_github_token_result!(state::AppState; verbose::Bool=false)
+    has_github_refresh_token(state) || return (success = false, reason = "no GitHub refresh token is available", retryable = false)
 
-    refresh_response = GitHubAuth.refresh_access_token(
+    refresh_result = GitHubAuth.refresh_access_token_result(
         state.github_refresh_token;
         dangerous_mode=state.dangerous_github_auth)
-    if isnothing(refresh_response)
-        return false
+    if isnothing(refresh_result.response)
+        return (success = false, reason = refresh_result.reason, retryable = refresh_result.retryable)
     end
 
-    store_github_token_response!(state, refresh_response)
+    store_github_token_response!(state, refresh_result.response)
     if verbose
         filename = state.dangerous_github_auth ? "github_tokens_dangerous.json" : "github_tokens.json"
         cprintln(CYAN, "   Token location: $(joinpath(state.claude_prefix, filename))")
     end
-    return true
+    return (success = true, reason = "", retryable = true)
+end
+
+function refresh_github_token!(state::AppState; verbose::Bool=false)
+    return refresh_github_token_result!(state; verbose).success
 end
 
 function seconds_until_github_token_refresh(state::AppState)
@@ -662,16 +669,27 @@ function seconds_until_github_token_refresh(state::AppState)
     return max(state.github_token_expires_at - time() - GITHUB_TOKEN_REFRESH_SKEW_SECONDS, 1.0)
 end
 
+next_github_token_refresh_retry_delay(delay::Real) =
+    min(Float64(delay) * 2, GITHUB_TOKEN_REFRESH_MAX_RETRY_SECONDS)
+
 function start_github_token_refresh_task!(state::AppState)
     has_github_refresh_token(state) || return nothing
     write_sandbox_github_token(state)
 
     return @async begin
+        retry_delay = GITHUB_TOKEN_REFRESH_INITIAL_RETRY_SECONDS
         while has_github_refresh_token(state)
             sleep(seconds_until_github_token_refresh(state))
-            if !refresh_github_token!(state)
-                @warn "ClaudeBox: failed to refresh GitHub token; will retry" token_file=github_token_file(state)
-                sleep(5 * 60)
+            refresh_result = refresh_github_token_result!(state)
+            if refresh_result.success
+                retry_delay = GITHUB_TOKEN_REFRESH_INITIAL_RETRY_SECONDS
+            elseif refresh_result.retryable
+                @warn "ClaudeBox: failed to refresh GitHub token; will retry with backoff" reason=refresh_result.reason retry_in_seconds=round(Int, retry_delay) token_file=github_token_file(state)
+                sleep(retry_delay)
+                retry_delay = next_github_token_refresh_retry_delay(retry_delay)
+            else
+                @warn "ClaudeBox: failed to refresh GitHub token; background refresh stopped" reason=refresh_result.reason token_file=github_token_file(state)
+                break
             end
         end
     end

--- a/src/github_auth.jl
+++ b/src/github_auth.jl
@@ -143,32 +143,92 @@ function get_user_info(token::String)
     return (login = "", name = "", email = "")
 end
 
-function refresh_access_token(refresh_token::String; dangerous_mode::Bool=false)
+function oauth_error_message(data)
+    if !haskey(data, "error")
+        return nothing
+    end
+
+    message = string(data["error"])
+    if haskey(data, "error_description") && !isempty(string(data["error_description"]))
+        message *= ": $(data["error_description"])"
+    end
+    if haskey(data, "error_uri") && !isempty(string(data["error_uri"]))
+        message *= " ($(data["error_uri"]))"
+    end
+    return message
+end
+
+token_refresh_error_is_retryable(data) =
+    get(data, "error", "") in ("slow_down", "server_error", "temporarily_unavailable")
+
+http_status_is_retryable(status::Integer) =
+    status == 408 || status == 409 || status == 425 || status == 429 || 500 <= status <= 599
+
+function response_body_snippet(response::HTTP.Response)
+    body = strip(replace(String(response.body), r"\s+" => " "))
+    return length(body) > 240 ? first(body, 240) * "..." : body
+end
+
+function refresh_access_token_result(refresh_token::String; dangerous_mode::Bool=false)
     client_id = dangerous_mode ? DANGEROUS_CLIENT_ID : DEFAULT_CLIENT_ID
     try
         response = HTTP.post(
             ACCESS_TOKEN_URL,
             ["Accept" => "application/json"],
-            "client_id=$(client_id)&refresh_token=$(refresh_token)&grant_type=refresh_token"
+            "client_id=$(client_id)&refresh_token=$(refresh_token)&grant_type=refresh_token";
+            status_exception=false
         )
 
-        if response.status == 200
-            data = JSON.parse(String(response.body))
-            if haskey(data, "access_token")
-                return AccessTokenResponse(
+        data = try
+            JSON.parse(String(response.body))
+        catch e
+            snippet = response_body_snippet(response)
+            reason = isempty(snippet) ?
+                "GitHub token endpoint returned HTTP $(response.status) with a non-JSON response: $(sprint(showerror, e))" :
+                "GitHub token endpoint returned HTTP $(response.status) with a non-JSON response: $snippet"
+            return (
+                response = nothing,
+                reason = reason,
+                retryable = http_status_is_retryable(response.status),
+            )
+        end
+        if response.status == 200 && haskey(data, "access_token")
+            return (
+                response = AccessTokenResponse(
                     data["access_token"],
                     data["token_type"],
                     data["scope"],
                     get(data, "refresh_token", refresh_token),  # May return same or new refresh token
                     get(data, "expires_in", nothing),
                     get(data, "refresh_token_expires_in", nothing)
-                )
-            end
+                ),
+                reason = "",
+                retryable = true,
+            )
         end
+
+        oauth_message = oauth_error_message(data)
+        reason = if isnothing(oauth_message)
+            "GitHub token endpoint returned HTTP $(response.status) without an access token"
+        else
+            "GitHub OAuth error: $oauth_message"
+        end
+        return (
+            response = nothing,
+            reason = reason,
+            retryable = http_status_is_retryable(response.status) || token_refresh_error_is_retryable(data),
+        )
     catch e
-        # Refresh failed, return nothing
+        return (
+            response = nothing,
+            reason = "exception while refreshing token: $(sprint(showerror, e))",
+            retryable = true,
+        )
     end
-    return nothing
+end
+
+function refresh_access_token(refresh_token::String; dangerous_mode::Bool=false)
+    return refresh_access_token_result(refresh_token; dangerous_mode=dangerous_mode).response
 end
 
 function check_claude_sandbox_repo(token::String)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,6 +177,8 @@ const IS_CI = haskey(ENV, "JULIA_PKGTEST") || haskey(ENV, "CI")
 
             @test ClaudeBox.has_github_refresh_token(state)
             @test ClaudeBox.seconds_until_github_token_refresh(state) > 3000
+            @test ClaudeBox.next_github_token_refresh_retry_delay(ClaudeBox.GITHUB_TOKEN_REFRESH_INITIAL_RETRY_SECONDS) == 10 * 60.0
+            @test ClaudeBox.next_github_token_refresh_retry_delay(ClaudeBox.GITHUB_TOKEN_REFRESH_MAX_RETRY_SECONDS) == ClaudeBox.GITHUB_TOKEN_REFRESH_MAX_RETRY_SECONDS
 
             ClaudeBox.write_sandbox_github_token(state)
             token_file = ClaudeBox.github_token_file(state)
@@ -209,6 +211,22 @@ const IS_CI = haskey(ENV, "JULIA_PKGTEST") || haskey(ENV, "CI")
 
             cmd = string(ClaudeBox.build_cli_command(state))
             @test !occursin("--mcp-config", cmd)
+
+            oauth_error = Dict(
+                "error" => "bad_refresh_token",
+                "error_description" => "The refresh token is invalid"
+            )
+            @test ClaudeBox.GitHubAuth.oauth_error_message(oauth_error) == "bad_refresh_token: The refresh token is invalid"
+            @test !ClaudeBox.GitHubAuth.token_refresh_error_is_retryable(oauth_error)
+            @test ClaudeBox.GitHubAuth.token_refresh_error_is_retryable(Dict("error" => "temporarily_unavailable"))
+            @test ClaudeBox.GitHubAuth.http_status_is_retryable(500)
+            @test !ClaudeBox.GitHubAuth.http_status_is_retryable(400)
+
+            state.github_refresh_token = nothing
+            refresh_result = ClaudeBox.refresh_github_token_result!(state)
+            @test refresh_result.success == false
+            @test refresh_result.retryable == false
+            @test occursin("no GitHub refresh token", refresh_result.reason)
         end
     end
 


### PR DESCRIPTION
## Summary

Adds structured GitHub token refresh results and backs off retryable background refresh failures instead of retrying every five minutes forever.

## Motivation

The host refresh loop previously treated every refresh failure the same. Transient GitHub endpoint failures and permanent OAuth errors both produced a generic failure, so the background task could keep retrying invalid refresh tokens without useful diagnostics.

## Changes

- Return refresh result metadata with a failure reason and retryability flag.
- Classify retryable HTTP and OAuth token-refresh failures.
- Use exponential backoff for retryable background refresh failures and stop the background task for non-retryable failures.
- Preserve the existing boolean `refresh_github_token!` API as a wrapper.
- Add tests for retry delay and error classification behavior.

## Validation

- `CI=true julia --project=. -e 'using Pkg; Pkg.test()'`