### PR TITLE
Mount external git worktree dir read-only in the sandbox

### DIFF
--- a/src/ClaudeBox.jl
+++ b/src/ClaudeBox.jl
@@ -43,6 +43,45 @@ function lexists(path::AbstractString)
     return ispath(lstat(path))
 end
 
+# When the workspace is a git worktree, its top-level `.git` is a file of the
+# form `gitdir: /path/to/mainrepo/.git/worktrees/<name>` rather than a
+# directory. That gitdir (and the shared "common dir" it links to) live outside
+# the workspace, so git operations fail inside the sandbox unless those paths
+# are made available at their original locations. This returns the host paths
+# that need to be mounted (the common dir and, if separate, the worktree
+# gitdir), or an empty vector if the workspace is not a git worktree.
+function git_worktree_gitdirs(work_dir::AbstractString)
+    dotgit = joinpath(work_dir, ".git")
+    isfile(dotgit) || return String[]
+    content = try
+        read(dotgit, String)
+    catch
+        return String[]
+    end
+    m = match(r"^gitdir:\s*(.+?)\s*$"m, content)
+    m === nothing && return String[]
+    # Normalize by stripping any trailing slash left by `..` resolution so the
+    # containment check below and the mount paths stay clean.
+    norm(p) = (s = rstrip(String(p), '/'); isempty(s) ? "/" : s)
+    gitdir = String(strip(m.captures[1]))
+    isabspath(gitdir) || (gitdir = abspath(joinpath(work_dir, gitdir)))
+    gitdir = norm(gitdir)
+    isdir(gitdir) || return String[]
+    paths = [gitdir]
+    # The common dir holds the shared object store/refs; for a standard worktree
+    # it is the parent repo's `.git`, an ancestor of gitdir.
+    commondir_file = joinpath(gitdir, "commondir")
+    if isfile(commondir_file)
+        common = String(strip(read(commondir_file, String)))
+        isabspath(common) || (common = abspath(joinpath(gitdir, common)))
+        common = norm(common)
+        isdir(common) && push!(paths, common)
+    end
+    # Drop any path nested inside another candidate (keep the outermost), so we
+    # don't create redundant overlapping mounts.
+    return filter(p -> !any(q -> q != p && startswith(p, rstrip(q, '/') * "/"), paths), paths)
+end
+
 mutable struct AppState
     tools_prefix::String
     claude_prefix::String
@@ -1261,6 +1300,20 @@ function create_sandbox_config(state::AppState; stdin=Base.devnull, stdout=Base.
         "/root/.julia" => Sandbox.MountInfo(state.julia_dir, Sandbox.MountType.ReadWrite),
         "/root/.local" => Sandbox.MountInfo(state.local_dir, Sandbox.MountType.ReadWrite)
     )
+
+    # If the workspace is a git worktree, its `.git` file points at a gitdir (and
+    # shared common dir) that live outside the workspace. Mount them read-only at
+    # their original host paths so git resolves the worktree inside the sandbox.
+    for gitpath in git_worktree_gitdirs(state.work_dir)
+        # Skip anything already covered by an existing (non-root) mount. The
+        # root mount "/" is excluded: every mount is nested under it, so it would
+        # spuriously "cover" every absolute path.
+        covered = any(p -> p != "/" && (gitpath == p || startswith(gitpath, rstrip(p, '/') * "/")), keys(mounts))
+        if !covered
+            mounts[gitpath] = Sandbox.MountInfo(gitpath, Sandbox.MountType.ReadOnly)
+            cprintln(CYAN, "📁 Mounting git worktree directory (read-only): $gitpath")
+        end
+    end
 
     # Add claude_sandbox repository if available
     if !isnothing(state.claude_sandbox_dir) && isdir(state.claude_sandbox_dir)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,6 +134,47 @@ const IS_CI = haskey(ENV, "JULIA_PKGTEST") || haskey(ENV, "CI")
         end
     end
 
+    @testset "Git Worktree Mounts" begin
+        # A workspace whose `.git` is a real directory is not a worktree.
+        mktempdir() do dir
+            mkdir(joinpath(dir, ".git"))
+            @test isempty(ClaudeBox.git_worktree_gitdirs(dir))
+        end
+
+        # A workspace with no `.git` at all is not a worktree.
+        mktempdir() do dir
+            @test isempty(ClaudeBox.git_worktree_gitdirs(dir))
+        end
+
+        # A worktree: `.git` is a file pointing at a gitdir whose `commondir`
+        # resolves to the parent repo's `.git`. Only the (outermost) common dir
+        # should be returned, since it contains the worktree gitdir.
+        mktempdir() do root
+            gitdir = joinpath(root, "main", ".git", "worktrees", "wt1")
+            common = joinpath(root, "main", ".git")
+            wt = joinpath(root, "wt")
+            mkpath(gitdir)
+            mkpath(wt)
+            write(joinpath(wt, ".git"), "gitdir: $gitdir\n")
+            write(joinpath(gitdir, "commondir"), "../..\n")
+            @test ClaudeBox.git_worktree_gitdirs(wt) == [common]
+        end
+
+        # A worktree whose gitdir is not nested under its common dir: both paths
+        # are returned.
+        mktempdir() do root
+            gitdir = joinpath(root, "wtmeta")
+            common = joinpath(root, "repo", ".git")
+            wt = joinpath(root, "wt")
+            mkpath(gitdir)
+            mkpath(common)
+            mkpath(wt)
+            write(joinpath(wt, ".git"), "gitdir: $gitdir\n")
+            write(joinpath(gitdir, "commondir"), common)
+            @test sort(ClaudeBox.git_worktree_gitdirs(wt)) == sort([gitdir, common])
+        end
+    end
+
     @testset "install_jll_tool artifact path types" begin
         # Regression test for issue #23: collect_artifact_paths returns a
         # Dict{PackageSpec, Vector{String}}, which must be passed directly to


### PR DESCRIPTION
## Summary

When the workspace is a git worktree, its top-level `.git` is a *file* (e.g. `gitdir: /home/vtjnash/julia/.git/worktrees/julia-opus`) rather than a directory. The referenced gitdir and the shared "common dir" it links to live **outside** the workspace, so git operations fail inside the sandbox because those paths don't exist there.

This change detects that case and bind-mounts the required host paths **read-only at their original locations** (the same "preserve" semantics as `--preserve`), so git resolves the worktree inside the sandbox. A line is printed on startup reporting the mount.

## Details

- New helper `git_worktree_gitdirs(work_dir)`:
  - Returns `[]` when `.git` is a normal directory or absent (ordinary repo — nothing to do).
  - Parses the `gitdir:` path from the `.git` file.
  - Resolves the shared common dir via the gitdir's `commondir` file.
  - Deduplicates nested paths, keeping the outermost (for a standard worktree the gitdir lives under the common `.git`, so only the common dir is mounted).
- `create_sandbox_config` mounts each resulting host path as `ReadOnly` at the same path, skipping anything already covered by an existing **non-root** mount. The root mount `/` is explicitly excluded from that check — every mount is nested under it, so it would otherwise spuriously "cover" every absolute path.

## Notes

- The mount is **read-only** as intended: `git status`/`log`/`diff` work, but `git commit`/`add` will fail since the worktree index/HEAD live under the mounted gitdir. Can be switched to read-write if write support is desired.

## Testing

- Added a "Git Worktree Mounts" testset covering: a normal `.git` directory, a missing `.git`, a standard nested worktree (returns only the common dir), and a non-nested worktree gitdir (returns both paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)