### PR TITLE
Prefer host git identity over GitHub for sandbox gitconfig

### DIFF
--- a/src/ClaudeBox.jl
+++ b/src/ClaudeBox.jl
@@ -43,6 +43,45 @@ function lexists(path::AbstractString)
     return ispath(lstat(path))
 end
 
+# When the workspace is a git worktree, its top-level `.git` is a file of the
+# form `gitdir: /path/to/mainrepo/.git/worktrees/<name>` rather than a
+# directory. That gitdir (and the shared "common dir" it links to) live outside
+# the workspace, so git operations fail inside the sandbox unless those paths
+# are made available at their original locations. This returns the host paths
+# that need to be mounted (the common dir and, if separate, the worktree
+# gitdir), or an empty vector if the workspace is not a git worktree.
+function git_worktree_gitdirs(work_dir::AbstractString)
+    dotgit = joinpath(work_dir, ".git")
+    isfile(dotgit) || return String[]
+    content = try
+        read(dotgit, String)
+    catch
+        return String[]
+    end
+    m = match(r"^gitdir:\s*(.+?)\s*$"m, content)
+    m === nothing && return String[]
+    # Normalize by stripping any trailing slash left by `..` resolution so the
+    # containment check below and the mount paths stay clean.
+    norm(p) = (s = rstrip(String(p), '/'); isempty(s) ? "/" : s)
+    gitdir = String(strip(m.captures[1]))
+    isabspath(gitdir) || (gitdir = abspath(joinpath(work_dir, gitdir)))
+    gitdir = norm(gitdir)
+    isdir(gitdir) || return String[]
+    paths = [gitdir]
+    # The common dir holds the shared object store/refs; for a standard worktree
+    # it is the parent repo's `.git`, an ancestor of gitdir.
+    commondir_file = joinpath(gitdir, "commondir")
+    if isfile(commondir_file)
+        common = String(strip(read(commondir_file, String)))
+        isabspath(common) || (common = abspath(joinpath(gitdir, common)))
+        common = norm(common)
+        isdir(common) && push!(paths, common)
+    end
+    # Drop any path nested inside another candidate (keep the outermost), so we
+    # don't create redundant overlapping mounts.
+    return filter(p -> !any(q -> q != p && startswith(p, rstrip(q, '/') * "/"), paths), paths)
+end
+
 mutable struct AppState
     tools_prefix::String
     claude_prefix::String
@@ -1261,6 +1300,20 @@ function create_sandbox_config(state::AppState; stdin=Base.devnull, stdout=Base.
         "/root/.julia" => Sandbox.MountInfo(state.julia_dir, Sandbox.MountType.ReadWrite),
         "/root/.local" => Sandbox.MountInfo(state.local_dir, Sandbox.MountType.ReadWrite)
     )
+
+    # If the workspace is a git worktree, its `.git` file points at a gitdir (and
+    # shared common dir) that live outside the workspace. Mount them read-only at
+    # their original host paths so git resolves the worktree inside the sandbox.
+    for gitpath in git_worktree_gitdirs(state.work_dir)
+        # Skip anything already covered by an existing (non-root) mount. The
+        # root mount "/" is excluded: every mount is nested under it, so it would
+        # spuriously "cover" every absolute path.
+        covered = any(p -> p != "/" && (gitpath == p || startswith(gitpath, rstrip(p, '/') * "/")), keys(mounts))
+        if !covered
+            mounts[gitpath] = Sandbox.MountInfo(gitpath, Sandbox.MountType.ReadOnly)
+            cprintln(CYAN, "📁 Mounting git worktree directory (read-only): $gitpath")
+        end
+    end
 
     # Add claude_sandbox repository if available
     if !isnothing(state.claude_sandbox_dir) && isdir(state.claude_sandbox_dir)

--- a/src/ClaudeBox.jl
+++ b/src/ClaudeBox.jl
@@ -82,6 +82,18 @@ function git_worktree_gitdirs(work_dir::AbstractString)
     return filter(p -> !any(q -> q != p && startswith(p, rstrip(q, '/') * "/"), paths), paths)
 end
 
+# Read a single value (e.g. "user.name") from the host's git config, letting git
+# resolve its normal config hierarchy, so the sandbox can inherit the user's real
+# git identity. Returns `nothing` when the key is unset or git is unavailable.
+function host_git_config(key::AbstractString)
+    value = try
+        strip(read(`git config --get $key`, String))
+    catch
+        return nothing
+    end
+    return isempty(value) ? nothing : String(value)
+end
+
 mutable struct AppState
     tools_prefix::String
     claude_prefix::String
@@ -962,7 +974,9 @@ function setup_environment!(state::AppState)
 
     # Create a global gitconfig with SSL settings and user info
     gitconfig_path = joinpath(state.tools_prefix, "gitconfig")
-    if !isfile(gitconfig_path) || !isempty(state.github_token)
+    host_name = host_git_config("user.name")
+    host_email = host_git_config("user.email")
+    if !isfile(gitconfig_path) || !isempty(state.github_token) || !isnothing(host_name) || !isnothing(host_email)
         # Get user info from GitHub if we have a token
         user_name = "Sandbox User"
         user_email = "sandbox@localhost"
@@ -980,6 +994,14 @@ function setup_environment!(state::AppState)
             elseif !isnothing(user_info.login) && !isempty(user_info.login)
                 user_email = "$(user_info.login)@users.noreply.github.com"
             end
+        end
+
+        # Prefer the host's global git config identity over GitHub-derived values
+        if !isnothing(host_name)
+            user_name = host_name
+        end
+        if !isnothing(host_email)
+            user_email = host_email
         end
 
         write(gitconfig_path, """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -313,6 +313,33 @@ const IS_CI = haskey(ENV, "JULIA_PKGTEST") || haskey(ENV, "CI")
         @test mounts["/root/.gitconfig"].host_path == gitconfig_path
     end
 
+    @testset "Host git config identity" begin
+        mktempdir() do dir
+            cfg = joinpath(dir, "gitconfig")
+            # Point git at a controlled global config and ignore system config, so
+            # the test exercises git's normal resolution without hard-coded paths.
+            # Run from the (non-repo) temp dir so no local config leaks in.
+            withenv("GIT_CONFIG_GLOBAL" => cfg, "GIT_CONFIG_NOSYSTEM" => "1") do
+                cd(dir) do
+                    # Missing/empty config yields nothing
+                    @test ClaudeBox.host_git_config("user.name") === nothing
+
+                    # Populated identity is read back
+                    write(cfg, """
+                    [user]
+                        name = Ada Lovelace
+                        email = ada@example.com
+                    """)
+                    @test ClaudeBox.host_git_config("user.name") == "Ada Lovelace"
+                    @test ClaudeBox.host_git_config("user.email") == "ada@example.com"
+
+                    # Unset key yields nothing
+                    @test ClaudeBox.host_git_config("user.signingkey") === nothing
+                end
+            end
+        end
+    end
+
     @testset "Gemini Configuration Mounting" begin
         # Test with gemini mode enabled
         state_gemini = ClaudeBox.initialize_state(pwd(), String[], false, false, true, false, false)  # use_gemini = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -134,6 +134,47 @@ const IS_CI = haskey(ENV, "JULIA_PKGTEST") || haskey(ENV, "CI")
         end
     end
 
+    @testset "Git Worktree Mounts" begin
+        # A workspace whose `.git` is a real directory is not a worktree.
+        mktempdir() do dir
+            mkdir(joinpath(dir, ".git"))
+            @test isempty(ClaudeBox.git_worktree_gitdirs(dir))
+        end
+
+        # A workspace with no `.git` at all is not a worktree.
+        mktempdir() do dir
+            @test isempty(ClaudeBox.git_worktree_gitdirs(dir))
+        end
+
+        # A worktree: `.git` is a file pointing at a gitdir whose `commondir`
+        # resolves to the parent repo's `.git`. Only the (outermost) common dir
+        # should be returned, since it contains the worktree gitdir.
+        mktempdir() do root
+            gitdir = joinpath(root, "main", ".git", "worktrees", "wt1")
+            common = joinpath(root, "main", ".git")
+            wt = joinpath(root, "wt")
+            mkpath(gitdir)
+            mkpath(wt)
+            write(joinpath(wt, ".git"), "gitdir: $gitdir\n")
+            write(joinpath(gitdir, "commondir"), "../..\n")
+            @test ClaudeBox.git_worktree_gitdirs(wt) == [common]
+        end
+
+        # A worktree whose gitdir is not nested under its common dir: both paths
+        # are returned.
+        mktempdir() do root
+            gitdir = joinpath(root, "wtmeta")
+            common = joinpath(root, "repo", ".git")
+            wt = joinpath(root, "wt")
+            mkpath(gitdir)
+            mkpath(common)
+            mkpath(wt)
+            write(joinpath(wt, ".git"), "gitdir: $gitdir\n")
+            write(joinpath(gitdir, "commondir"), common)
+            @test sort(ClaudeBox.git_worktree_gitdirs(wt)) == sort([gitdir, common])
+        end
+    end
+
     @testset "install_jll_tool artifact path types" begin
         # Regression test for issue #23: collect_artifact_paths returns a
         # Dict{PackageSpec, Vector{String}}, which must be passed directly to


### PR DESCRIPTION
## Summary
- Read `user.name` / `user.email` from the host's git config via `git config --get` (letting git resolve its normal config hierarchy — global, system, includes) and use those values for the sandbox gitconfig in preference to the GitHub-derived identity.
- Precedence is now: **host git identity → GitHub → built-in defaults** (`Sandbox User` / `sandbox@localhost`).
- Adds a `host_git_config(key)` helper that returns `nothing` when the key is unset or git is unavailable.

## Testing
- New "Host git config identity" testset exercises git's normal resolution via `GIT_CONFIG_GLOBAL` (with `GIT_CONFIG_NOSYSTEM=1`, run from a non-repo temp dir): missing config, populated identity, and unset key.

> Note: stacked on top of #30. The diff will include the #30 commit until that merges, after which this narrows to just the gitconfig change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)